### PR TITLE
Pin version of flowgen to 1.11.0.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10398,6 +10398,20 @@
           "integrity": "sha512-bYL2d05vOSf1JEZNx5vSAtPuBMkX8K9EUutg7zlKvTqKXHt7RhWJFbmd7qakVuf13i+IkGmp6FwSsONOf6VYIg==",
           "dev": true
         },
+        "flowgen": {
+          "version": "1.11.0",
+          "resolved": "https://registry.npmjs.org/flowgen/-/flowgen-1.11.0.tgz",
+          "integrity": "sha512-WpoBjzcZadnAw5FatlUbvFWUWXkI2/LjrwTl5fl3MVDh+KdvYgFzgRXDDKH/O2uUlwjfpveiJJJx8TwL7Se84A==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "@babel/highlight": "^7.9.0",
+            "lodash": "^4.17.15",
+            "shelljs": "^0.8.4",
+            "typescript": "^3.4",
+            "typescript-compiler": "^1.4.1-2"
+          }
+        },
         "get-stream": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "eslint-watch": "7.0.0",
     "flow-bin": "^0.129.0",
     "flow-typed": "^3.2.0",
+    "flowgen": "1.11.0",
     "gh-pages": "3.1.0",
     "identity-obj-proxy": "3.0.0",
     "jest": "26.1.0",


### PR DESCRIPTION
## Description

Pin version of inner dependency on flowgen to 1.11.0 to avoid linter errors caused by lib change in 1.12.0.


