### PR TITLE
Fix pinned version to yarn's liking.

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,5 +127,8 @@
     "stylelint": "13.6.1",
     "stylelint-config-recommended-scss": "4.2.0",
     "stylelint-scss": "3.18.0"
+  },
+  "resolutions": {
+    "flowgen": "1.11.0"
   }
 }


### PR DESCRIPTION
## Description

First "fix" to pin version was pretty much ignored by yarn.  Via https://github.com/yarnpkg/rfcs/blob/master/implemented/0000-selective-versions-resolutions.md, added "resolutions" object to package.json and pinned flowgen to 1.11.0.  Worked on my machine! :)